### PR TITLE
Add std_srvs dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
     <depend>geometry_msgs</depend>
     <depend>message_runtime</depend>
     <depend>std_msgs</depend>
+    <depend>std_srvs</depend>
     <depend>nav_core</depend>
     <depend>nav_msgs</depend>
     <depend>tf2</depend>


### PR DESCRIPTION
Add `std_srvs` dependency to `package.xml`, fixing the build issue when using catkin. Fix #4 