### PR TITLE
add libqt5serialport5-dev as depend

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
     <depend>message_runtime</depend>
     <depend>std_msgs</depend>
     <depend>std_srvs</depend>
+    <depend>libqt5serialport5-dev</depend>
     <depend>nav_core</depend>
     <depend>nav_msgs</depend>
     <depend>tf2</depend>


### PR DESCRIPTION
work in progress.
this PR is checking if CI can pass the build with `libqt5serialport5-dev`.