### PR TITLE
Backported ROS2 changes for updated witmotion_IMU_QT

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Configuration of the node is done by default via the configuration YAML file [`c
 - `port` - the virtual kernel device name for a port, `ttyUSB0` by default
 - `baud_rate` - port rate value to be used by the library for opening the port, _9600 baud_ by default
 - `polling_interval` - the sensor polling interval in milliseconds. If this parameter is omitted, the default value is set up by the library (50 ms).
+- `timeout_ms` - the sensor timeout period in milliseconds.  If no data is received from the sensor after this period, then an error is raised and the node terminates. If this parameter is omitted, a default value of 3 times the polling interval is used.  If this parameter is zero, the timeout check is disabled.
 - `restart_service_name` - the service name used to restart the sensor connection after an error.
 - `imu_publisher:`
     - `topic_name` - the topic name for IMU data publisher, `imu` in the node's namespace by default

--- a/config/config.yml
+++ b/config/config.yml
@@ -2,6 +2,7 @@ witmotion_imu:
     port: ttyUSB0
     baud_rate: 9600 # baud
     polling_interval: 50 # ms
+    timeout_ms: 150 # ms
     restart_service_name: /restart_imu
     imu_publisher:
         topic_name: /imu

--- a/config/wt31n.yml
+++ b/config/wt31n.yml
@@ -2,6 +2,7 @@ witmotion_imu:
     port: ttyUSB0
     baud_rate: 115200 # baud
     polling_interval: 10 # ms
+    timeout_ms: 150 # ms
     restart_service_name: /restart_imu
     imu_publisher:
         topic_name: /imu

--- a/config/wt901.yml
+++ b/config/wt901.yml
@@ -2,6 +2,7 @@ witmotion_imu:
     port: ttyUSB0
     baud_rate: 115200 # baud
     polling_interval: 10 # ms
+    timeout_ms: 150 # ms
     restart_service_name: /restart_imu
     imu_publisher:
         topic_name: /imu

--- a/include/witmotion_ros.h
+++ b/include/witmotion_ros.h
@@ -43,6 +43,7 @@ private:
     std::string port_name;
     QSerialPort::BaudRate port_rate;
     uint32_t interval;
+    uint32_t timeout_ms;
     QThread reader_thread;
     QBaseSerialWitmotionSensorReader* reader;
     static bool suspended;

--- a/src/witmotion_ros.cpp
+++ b/src/witmotion_ros.cpp
@@ -211,6 +211,13 @@ ROSWitmotionSensorController::ROSWitmotionSensorController():
        interval = static_cast<uint32_t>(int_interval);
        reader->SetSensorPollInterval(interval);
     }
+    if(node.hasParam("timeout_ms"))
+    {
+       int int_timeout_ms;
+       node.param<int>("timeout_ms", int_timeout_ms, 10);
+       timeout_ms = static_cast<uint32_t>(int_timeout_ms);
+       reader->SetSensorTimeout(timeout_ms);
+    }
     reader->ValidatePackets(true);
     reader->moveToThread(&reader_thread);
     connect(&reader_thread, &QThread::finished, reader, &QObject::deleteLater);


### PR DESCRIPTION
Mimics the changes made in the ROS2 branch in response to the recent update to the underlying witmotion_IMU_QT library.  This PR is the ROS1 version of https://github.com/ElettraSciComp/witmotion_IMU_ros/pull/26